### PR TITLE
Changes for initial PSM Unity (1.05 and 1.06) support.

### DIFF
--- a/cleanup.c
+++ b/cleanup.c
@@ -32,7 +32,7 @@ typedef u32_t (*sceCtrlPeekBufferPositive_func)(int, u32_t*, int);
 static sceCtrlPeekBufferPositive_func sceCtrlPeekBufferPositive_syscall;
 
 /********************************************//**
- *  \brief Convert L and R button values to what is expected..
+ *  \brief Convert L and R button values to what is expected.
  ***********************************************/
 u32_t
 uvl_wrapper_sceCtrlPeekBufferPositive(int port,
@@ -92,10 +92,7 @@ int index)  ///< An OR combination of flags (see defined "Search flags for impor
 
         uvl_add_func_by_ptr(0x5795E898, RESOLVE_TYPE_FUNCTION, (void*) (unitybaseseg0 + 0x9EEC6C)); // sceDisplayWaitVblankStart
         uvl_add_func_by_ptr(0xFF082DF0, RESOLVE_TYPE_FUNCTION, (void*) (unitybaseseg0 + 0x9EECCC)); // sceTouchPeek
-
-        void* sceCtrlPeekBufferPositive_ptr = &uvl_wrapper_sceCtrlPeekBufferPositive;
-        uvl_add_func_by_ptr(0xA9C3CED6, RESOLVE_TYPE_FUNCTION, (void*) (sceCtrlPeekBufferPositive_ptr)); // sceCtrlPeekBufferPositive
-        sceCtrlPeekBufferPositive_syscall = (sceCtrlPeekBufferPositive_func) (unitybaseseg0 + 0x9EEC8C);
+        uvl_add_func_by_ptr(0xA9C3CED6, RESOLVE_TYPE_FUNCTION, (void*) (unitybaseseg0 + 0x9EEC8C)); // sceCtrlPeekBufferPositive
 
         uvl_lock_mem();
     }

--- a/cleanup.h
+++ b/cleanup.h
@@ -11,7 +11,8 @@
 #include "types.h"
 
 int uvl_cleanup_memory ();
-int uvl_unload_all_modules ();
+int uvl_unload_all_modules();
+void uvl_pre_clean();
 
 #endif
 /// @}

--- a/config.h
+++ b/config.h
@@ -6,8 +6,8 @@
 #ifndef UVL_CONFIG
 #define UVL_CONFIG
 
-#define UVL_HOMEBREW_PATH               "pss0:/top/Documents/homebrew.self"     ///< Where to load the homebrew.
-#define UVL_LOG_PATH                    "pss0:/top/Documents/uvloader.log"      ///< Where to print the log
+#define UVL_HOMEBREW_PATH               "cache0:/VitaDefilerClient/Documents/homebrew.self"     ///< Where to load the homebrew.
+#define UVL_LOG_PATH                    "cache0:/VitaDefilerClient/Documents/uvloader.log"      ///< Where to print the log
 
 #endif
 /// @}

--- a/resolve.c
+++ b/resolve.c
@@ -731,8 +731,9 @@ uvl_find_module_info (loaded_module_info_t *m_mod_info) ///< Loaded module infor
         }
         // try making this the one
         mod_info = (module_info_t*)((u32_t)result - 4);
-        IF_VERBOSE LOG ("Possible module info struct at 0x%X", (u32_t)mod_info);
-        if (mod_info->modattribute == MOD_INFO_VALID_ATTR && mod_info->modversion == MOD_INFO_VALID_VER) // TODO: Better check
+        IF_VERBOSE LOG("Possible module info struct at 0x%X", (u32_t) mod_info);
+        if (mod_info->modattribute == MOD_INFO_VALID_ATTR && (mod_info->modversion == MOD_INFO_VALID_VER
+        || mod_info->modversion == 0x0403 || mod_info->modversion == 0x0)) // TODO: Better check
         {
             IF_VERBOSE LOG ("Module export start at 0x%X import start at 0x%X", (u32_t)mod_info->ent_top + (u32_t)m_mod_info->segments[0].vaddr, (u32_t)mod_info->stub_top + (u32_t)m_mod_info->segments[0].vaddr);
             break; // we found it

--- a/uvloader.c
+++ b/uvloader.c
@@ -191,6 +191,9 @@ uvl_start_load ()
     }
     IF_DEBUG LOG ("Adding UVL imports.");
     uvl_add_uvl_exports ();
+    
+    uvl_pre_clean();
+    
     IF_DEBUG LOG ("Loading homebrew.");
     if (uvl_load (UVL_HOMEBREW_PATH) < 0)
     {


### PR DESCRIPTION
I've made it so that UVLoader will work on regular PSM as well as PSM Unity without the need to recompile it. Unfortunately, that means using a hardcoded path to load homebrew that works on both versions, which is not ideal. There are likely several parts of this that can be done in a better way but I've tried the best I could with the time I've had.