### PR TITLE
Updated!

### DIFF
--- a/cleanup.c
+++ b/cleanup.c
@@ -192,12 +192,12 @@ uvl_clean_unity()
 
         if (unity_version == 0x106)
         {
+            uvl_add_syscall_relative(0x1b04a1d6, setConfigModeNid, -0x7); // scePowerGetGpuClockFrequency
+            uvl_add_syscall_relative(0x478fe6f5, setConfigModeNid, 0x2);  // scePowerGetBusClockFrequency
+            uvl_add_syscall_relative(0xb8d7b3fb, setConfigModeNid, 0x6);  // scePowerSetGpuClockFrequency
             uvl_add_syscall_relative(0x74db5ae5, setConfigModeNid, 0x7);  // scePowerSetArmClockFrequency
             uvl_add_syscall_relative(0xabc6f88f, setConfigModeNid, 0x11); // scePowerGetArmClockFrequency
-            uvl_add_syscall_relative(0xb8d7b3fb, setConfigModeNid, 0x6);  // scePowerSetBusClockFrequency
-            uvl_add_syscall_relative(0x478fe6f5, setConfigModeNid, -0x7); // scePowerGetBusClockFrequency
-            uvl_add_syscall_relative(0x717db06c, setConfigModeNid, 0x15); // scePowerSetGpuClockFrequency
-            uvl_add_syscall_relative(0x1b04a1d6, setConfigModeNid, 0x2);  // scePowerGetGpuClockFrequency
+            uvl_add_syscall_relative(0x717db06c, setConfigModeNid, 0x15); // scePowerSetBusClockFrequency
         }
 
         uvl_lock_mem();

--- a/load.h
+++ b/load.h
@@ -150,11 +150,11 @@ typedef struct uvl_loaded uvl_loaded_t;
 int uvl_load_file (const char *filename, void **data, PsvSSize *size);
 int uvl_load_exe (const char *filename, void **entry, uvl_loaded_t *loaded);
 int uvl_load_elf (void *data, void **entry, uvl_loaded_t *loaded);
-int uvl_load_module_for_lib (char *lib_name);
 /** @}*/
 /** \name Helper functions
  *  @{
  */
+int uvl_resolve_import_by_name(const char *name);
 int uvl_elf_check_header (Elf32_Ehdr_t *hdr);
 int uvl_elf_get_module_info (Elf32_Ehdr_t *elf_hdr, Elf32_Phdr_t *elf_phdrs, module_info_t **mod_info);
 //int uvl_elf_free_memory (Elf32_Phdr_t *prog_hdrs, int count);

--- a/resolve.h
+++ b/resolve.h
@@ -292,6 +292,8 @@ int uvl_resolve_imports (module_imports_t *import);
 int uvl_resolve_loader (u32_t nid, void *libkernel_base, void *stub);
 /** @}*/
 
+module_info_t *uvl_find_module_info (loaded_module_info_t *m_mod_info);
+
 // live resolving too slow
 #if 0
 /** \name Resolving entries

--- a/scefuncs.h
+++ b/scefuncs.h
@@ -78,6 +78,9 @@ STUB_FUNCTION(int, sceKernelUnloadModule);
 STUB_FUNCTION(int, sceClibVsnprintf);
 STUB_FUNCTION(int, sceKernelWaitThreadEnd);
 
+STUB_FUNCTION(int, sceAppMgrGetVs0UserModuleDrive);
+
 void uvl_scefuncs_resolve_loader (void *anchor);
+int uvl_resolve_appmgruser();
 
 #endif

--- a/uvloader.c
+++ b/uvloader.c
@@ -45,6 +45,7 @@ uvl_start (uvl_context_t *ctx)    ///< Pass in context information
 {
     uvl_init_from_context (ctx);
     uvl_scefuncs_resolve_loader (ctx->libkernel_anchor);
+    uvl_resolve_appmgruser();
     vita_init_log ();
     LOG ("UVLoader %u.%u.%u started.", UVL_VER_MAJOR, UVL_VER_MINOR, UVL_VER_REV);
     return uvl_start_load ();

--- a/uvloader.h
+++ b/uvloader.h
@@ -11,8 +11,8 @@
 #include "types.h"
 
 #define START_SECTION __attribute__ ((section (".text.start")))
-#define UVL_EXIT_NID        	0x826BBBAF      ///< NID of C exit() call
-#define UVL_PRINTF_NID        	0x9A004680      ///< NID of C printf() call
+#define UVL_EXIT_NID            0x826BBBAF      ///< NID of C exit() call
+#define UVL_PRINTF_NID            0x9A004680      ///< NID of C printf() call
 #define UVL_CODE_ALLOC_NID      0xBCEAB831      ///< uvl_alloc_code_mem
 #define UVL_CODE_UNLOCK_NID     0x98D1C91D      ///< uvl_unlock_mem
 #define UVL_CODE_LOCK_NID       0xEEC99826      ///< uvl_lock_mem
@@ -26,7 +26,7 @@
  *  @{
  */
 #define UVL_VER_MAJOR   1   ///< Major version
-#define UVL_VER_MINOR   1   ///< Minor version
+#define UVL_VER_MINOR   2   ///< Minor version
 #define UVL_VER_REV     0   ///< Revision
 /** @}*/
 

--- a/uvloader.h
+++ b/uvloader.h
@@ -12,7 +12,7 @@
 
 #define START_SECTION __attribute__ ((section (".text.start")))
 #define UVL_EXIT_NID            0x826BBBAF      ///< NID of C exit() call
-#define UVL_PRINTF_NID            0x9A004680      ///< NID of C printf() call
+#define UVL_PRINTF_NID          0x9A004680      ///< NID of C printf() call
 #define UVL_CODE_ALLOC_NID      0xBCEAB831      ///< uvl_alloc_code_mem
 #define UVL_CODE_UNLOCK_NID     0x98D1C91D      ///< uvl_unlock_mem
 #define UVL_CODE_LOCK_NID       0xEEC99826      ///< uvl_lock_mem


### PR DESCRIPTION
- Improved NID antidote by using sceAppMgrGetVs0UserModuleDrive to reload all modules at vs0:sys/external.
- Added support for weak imports in homebrews.
- sceKernelUnloadModule had only got one argument instead of three arguments, fixed.
- Power frequency syscalls were resolved incorrectly, fixed.
- Changed UVLoader version to 1.2.